### PR TITLE
Typo in go.mod

### DIFF
--- a/dart_api_dl/go.mod
+++ b/dart_api_dl/go.mod
@@ -1,3 +1,3 @@
-module githhub.com/mraleph/go_dart_ffi_example/dart_api_dl
+module github.com/mraleph/go_dart_ffi_example/dart_api_dl
 
 go 1.16


### PR DESCRIPTION
I was trying to use this example, but had some issues with go commands. 
Later I found this module file points githhub... not github.